### PR TITLE
Generalize OpenAI Provider to Support Local Compatible APIs

### DIFF
--- a/lua/ai/providers/openai.lua
+++ b/lua/ai/providers/openai.lua
@@ -39,8 +39,10 @@ M.parse_curl_args = function(provider, request)
 
   local headers = {
     ["Content-Type"] = "application/json",
-    ["Authorization"] = "Bearer " .. os.getenv(M.API_KEY),
   }
+  if not P.env.is_local("openai") then
+    headers["Authorization"] = "Bearer " .. os.getenv(M.API_KEY)
+  end
 
   local messages = {
     {


### PR DESCRIPTION
Modified the OpenAI provider to check if the provider is local and if it is, disregard the inclusion of an authorization header. Tested with llamacpp and koboldcpp.